### PR TITLE
Page parent and dropped non working PHP version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ["ubuntu-latest"]
-        php-versions: ["7.3", "7.4", "8"]
+        php-versions: ["7.4", "8"]
 
     steps:
       - uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ The `PageResource` class provides a convenience method for rendering the options
 Use it like this:
 
 ```php
-Select::make('My page')
-    ->options(PageResource::getPageOptionsForSelect())
+Select::make('My page')->options(PageResource::getPageOptionsForSelect());
 ```
 
 ## Integration with OptimistDigital/MenuBuilder

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.1.0",
+    "php": "~7.4 | ~8.0",
     "axn/laravel-eloquent-authorable": "^5.1",
     "gwd/seo-meta-nova-field": "^1.2",
     "laravel/nova": "^3.19",

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -235,13 +235,9 @@ class PageResource extends Resource
                     )
                     ->asHtml(),
 
-                BelongsTo::make(
-                    __('pages::pages.fields.parent'),
-                    'parent',
-                    static::class
-                )
-                    ->nullable()
-                    ->display('title'),
+                Select::make(__('pages::pages.fields.parent'), 'parent_id')
+                    ->options(self::getPageOptionsForSelect())
+                    ->displayUsingLabels(),
 
                 Select::make(__('pages::pages.fields.status'), 'status')
                     ->options($this->getPageStatusOptions())


### PR DESCRIPTION
- Parent pages are shown hierarchical
- Removed PHP 7.1, 7.2 and 7.3 from version constraint, because this pages heavily uses arrow functions, which are available from PHP 7.4