### PR TITLE
Ensure menu item orphans are deleted

### DIFF
--- a/src/Events/DeletedPage.php
+++ b/src/Events/DeletedPage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Grrr\Pages\Events;
+
+use Grrr\Pages\Models\Page;
+
+class DeletedPage
+{
+    public $page;
+
+    public function __construct(Page $page)
+    {
+        $this->page = $page;
+    }
+}

--- a/src/Listeners/DeleteConnectedMenuItems.php
+++ b/src/Listeners/DeleteConnectedMenuItems.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Grrr\Pages\Listeners;
+
+use Grrr\Pages\Events\DeletedPage;
+use OptimistDigital\MenuBuilder\Models\MenuItem;
+
+class DeleteConnectedMenuItems
+{
+    public function handle(DeletedPage $event): void
+    {
+        MenuItem::query()
+            ->where('data->page', $event->page->id)
+            ->delete();
+    }
+}

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -4,6 +4,7 @@ namespace Grrr\Pages\Models;
 
 use Axn\EloquentAuthorable\AuthorableTrait;
 use Grrr\Pages\Database\Factories\PageFactory;
+use Grrr\Pages\Events\DeletedPage;
 use Grrr\Pages\Events\SavingPage;
 use Grrr\Pages\Events\SavedPage;
 use Gwd\SeoMeta\Models\SeoMetaItem;
@@ -67,6 +68,7 @@ class Page extends Model
     protected $dispatchesEvents = [
         'saving' => SavingPage::class,
         'saved' => SavedPage::class,
+        'deleted' => DeletedPage::class,
     ];
 
     protected $guarded = [];

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -3,10 +3,12 @@
 namespace Grrr\Pages;
 
 use Grrr\Pages\Events\AttachedTranslation;
+use Grrr\Pages\Events\DeletedPage;
 use Grrr\Pages\Events\SavingPage;
 use Grrr\Pages\Events\SavedPage;
 use Grrr\Pages\Listeners\AttachBidirectionalTranslation;
 use Grrr\Pages\Listeners\UpdatePageUrl;
+use Grrr\Pages\Listeners\DeleteConnectedMenuItems;
 use Grrr\Pages\Listeners\UpdateChildPageUrls;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
@@ -36,6 +38,10 @@ class ToolServiceProvider extends ServiceProvider
         // Handle a page's URL composition.
         Event::listen(SavingPage::class, [UpdatePageUrl::class, 'handle']);
         Event::listen(SavedPage::class, [UpdateChildPageUrls::class, 'handle']);
+        Event::listen(DeletedPage::class, [
+            DeleteConnectedMenuItems::class,
+            'handle',
+        ]);
         Event::listen(AttachedTranslation::class, [
             AttachBidirectionalTranslation::class,
             'handle',

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use Grrr\Pages\ToolServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use OptimistDigital\MenuBuilder\MenuBuilderServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -32,11 +33,12 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->loadMigrationsFrom(__DIR__ . '../../../database/migrations');
     }
 
     protected function getPackageProviders($app)
     {
-        return [ToolServiceProvider::class];
+        return [ToolServiceProvider::class, MenuBuilderServiceProvider::class];
     }
 }


### PR DESCRIPTION
We've had all sorts of problems with projects in the wild where menu
items referenced previously removed pages.

In the CMS these won't show up anymore, but accessing their values will
cause problems either at the API-level or in the front-end consuming the
API.