### PR TITLE
Replace HasMany field for translations with Nova Multiselect field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
   "require": {
     "php": "~7.4 | ~8.0",
     "axn/laravel-eloquent-authorable": "^5.1",
-    "dillingham/nova-attach-many": "^1.3",
     "eminiarts/nova-tabs": "^1.4",
     "epartment/nova-dependency-container": "^1.3",
     "gwd/seo-meta-nova-field": "^1.2",
     "laravel/nova": "^3.19",
     "optimistdigital/nova-menu-builder": "^5.0",
+    "optimistdigital/nova-multiselect-field": "^2.3",
     "whitecube/nova-flexible-content": "^0.2.7"
   },
   "autoload": {

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -25,9 +25,8 @@ use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Laravel\Nova\Panel;
 use Laravel\Nova\Resource;
-use NovaAttachMany\AttachMany;
+use OptimistDigital\MultiselectField\Multiselect;
 use Whitecube\NovaFlexibleContent\Flexible;
 
 /**
@@ -244,6 +243,9 @@ class PageResource extends Resource
         // omit the dashes ("-") to show the level of nesting. This makes ordering
         // by URL really confusing.
         $query->orderBy('title');
+
+        // The Nova MultiSelect field will go through this method, but no resource information
+        // is added in the request. So this won't work with Nova MultiSelect.
         if (!$request->resourceId) {
             return $query;
         }
@@ -349,14 +351,12 @@ class PageResource extends Resource
                 ->onlyOnDetail(),
         ];
         if (config('nova-pages-tool.allowTranslations')) {
-            // AttachMany is visible in the form.
-            $basicFields[] = AttachMany::make(
+            $basicFields[] = Multiselect::make(
                 __('pages::pages.fields.translations'),
-                'translations',
-                self::class
+                'translations'
             )
-                ->showCounts()
-                ->showPreview();
+                ->belongsToMany(PageResource::class)
+                ->onlyOnForms();
         }
         return $basicFields;
     }


### PR DESCRIPTION
Since HasMany field does not support async fetching of options

Note: Nova Relatable Filtering is supported, BUT no resource
information is given in the request so we cannot modify the
query based on resource information.