### PR TITLE
Reference to static instead of self

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -308,7 +308,7 @@ class PageResource extends Resource
                 ->asHtml(),
 
             Select::make(__('pages::pages.fields.parent'), 'parent_id')
-                ->options(self::getPageOptionsForSelect())
+                ->options(static::getPageOptionsForSelect())
                 ->nullable()
                 ->displayUsingLabels(),
 


### PR DESCRIPTION
So we can overwrite the `getPageOptionsForSelect` function from the extended PageResource class.