### PR TITLE
Update Page.content definition to base Collection

### DIFF
--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -21,7 +21,7 @@ use Whitecube\NovaFlexibleContent\Value\FlexibleCast;
 
 /**
  * @property Collection $children
- * @property Collection $content
+ * @property \Illuminate\Support\Collection $content
  * @property array $metadata
  * @property int $id
  * @property string $language


### PR DESCRIPTION
Page::content is not a database collection, but can be any collection.
This fixes static analysis problems in that regard.