### PR TITLE
Use FRONTEND_URL when linking page

### DIFF
--- a/config/nova-pages-tool.php
+++ b/config/nova-pages-tool.php
@@ -14,4 +14,9 @@ return [
     'defaultTemplate' => \Grrr\Pages\Models\Page::TEMPLATE_DEFAULT,
 
     'seoImagesDisk' => env('SEO__DISK', 'public'),
+
+    // The URL to the front-end. Use this when you're using Nova as a headless
+    // CMS and the links from the CMS to the front-end should go to another
+    // host.
+    'frontendUrl' => env('FRONTEND_URL', ''),
 ];

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -300,10 +300,13 @@ class PageResource extends Resource
             Text::make(__('pages::pages.fields.url'), 'url')
                 ->hideWhenCreating()
                 ->hideWhenUpdating()
-                // @todo Make this configurable, because in headless CMS setups,
-                // this should not link to this server.
                 ->displayUsing(
-                    fn(string $url) => "<a href=\"{$url}\">{$url}</a>"
+                    fn(string $url) => sprintf(
+                        '<a href="%s">%s</a>',
+                        rtrim(config('nova-pages-tool.frontendUrl'), '/') .
+                            $url,
+                        $url
+                    )
                 )
                 ->asHtml(),
 


### PR DESCRIPTION
In a headless CMS, the pages shouldn't link to a relative URL, but use a full URL to the actual front-end host.