### PR TITLE
Define resource path on slug field

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -294,6 +294,9 @@ class PageResource extends Resource
                 ->from('title')
                 ->default('')
                 ->rules(['nullable', 'alpha_dash'])
+                ->withMeta([
+                    'resourceName' => self::uriKey(),
+                ])
                 ->help(__('pages::pages.fields.slugHelp'))
                 ->hideFromIndex(),
 


### PR DESCRIPTION
Currently the slug preview feature is not working because the usage the Nova Tabs package. Because it's wrapped inside a Tabs element, the resource path is passed in correctly and causes may 404 post requests to the nova api.

Now we explicitly define the resource route and the issue will be fixed. As seen on https://github.com/eminiarts/nova-tabs/issues/262