### PR TITLE
Allow axn/laravel-eloquent-authorable 7.x for Laravel 12 support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 5.1.0
+
+- Add support for Laravel 12 by allowing `axn/laravel-eloquent-authorable` 7.x.
+
 ## Version 5.0.0
 
 - Add support for Laravel Nova 5.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.1",
-    "axn/laravel-eloquent-authorable": "^6.3",
+    "axn/laravel-eloquent-authorable": "^6.3 || ^7.0",
     "laravel/nova": "^5.0",
     "outl1ne/nova-menu-builder": "^8.0",
     "outl1ne/nova-multiselect-field": "^5.0",


### PR DESCRIPTION
## Why

Schoolwijzer is upgrading its CMS to PHP 8.4 and Laravel 12. The only dependency blocking Laravel 12 there is this package's `axn/laravel-eloquent-authorable: ^6.3` constraint — 6.x supports Laravel 8–11 only.

## What

- Widen the constraint to `^6.3 || ^7.0`. Version 7.0 only raises the minimum PHP (8.4) and Laravel (12) versions; there are no API changes ([changelog](https://github.com/AXN-Informatique/laravel-eloquent-authorable/blob/master/CHANGELOG.md)).
- Add a CHANGELOG entry for v5.1.0.

After merging, please tag `v5.1.0` so consuming projects can require `^5.1`.